### PR TITLE
feat: add vault routing functionality to USSI contract

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ gas_reports = ["*"]
 ast = true
 build_info = true
 extra_output = ["storageLayout"]
+via_ir = true
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 remappings = [
   "@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/",

--- a/src/USSI.sol
+++ b/src/USSI.sol
@@ -326,7 +326,6 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
             }
             issuer.burnFor(hedgeOrder.assetID, hedgeOrder.inAmount);
         } else {
-            require(hedgeOrder.vault != address(0), "vault is zero address");
             IERC20(hedgeOrder.token).safeTransfer(hedgeOrder.vault, hedgeOrder.inAmount);
         }
         emit ConfirmMint(orderHash);

--- a/src/USSI.sol
+++ b/src/USSI.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
-import "forge-std/console.sol";
+// import "forge-std/console.sol";
 
 contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ERC20Upgradeable, UUPSUpgradeable, PausableUpgradeable {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -37,6 +37,7 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
         address requester;
         address receiver;
         address token;
+        address vault;
     }
 
     EnumerableSet.Bytes32Set orderHashs;
@@ -61,6 +62,8 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
 
     EnumerableSet.AddressSet supportTokens;
     address public vault;
+    mapping(address => address) public vaultRoutes;
+    EnumerableSet.AddressSet routeRequesters;
 
     event AddAssetID(uint256 assetID);
     event RemoveAssetID(uint256 assetID);
@@ -77,6 +80,9 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
     event CancelMint(bytes32 orderHash);
     event CancelRedeem(bytes32 orderHash);
     event UpdateVault(address oldVault, address vault);
+    event AddVaultRoute(address requester, address vault);
+    event RemoveVaultRoute(address requester);
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -162,6 +168,38 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
         emit UpdateVault(oldVault, vault);
     }
 
+    function getVaultRoute(address requester) public view returns (address) {
+        if (vaultRoutes[requester] == address(0)) {
+            return vault;
+        }
+        return vaultRoutes[requester];
+    }
+
+    function addVaultRoute(address requester, address vault_) external onlyOwner {
+        require(vault_ != address(0), "vault is zero address");
+        require(vaultRoutes[requester] != vault_, "vault route not change");
+        vaultRoutes[requester] = vault_;
+        routeRequesters.add(requester);
+        emit AddVaultRoute(requester, vault_);
+    }
+
+    function removeVaultRoute(address requester) external onlyOwner {
+        require(vaultRoutes[requester] != address(0), "vault route not exists");
+        delete vaultRoutes[requester];
+        routeRequesters.remove(requester);
+        emit RemoveVaultRoute(requester);
+    }
+
+    // @dev only for off-chain use
+    function getVaultRoutes() external view returns (address[] memory requesters, address[] memory vaults) {
+        requesters = new address[](routeRequesters.length());
+        vaults = new address[](routeRequesters.length());
+        for (uint i = 0; i < routeRequesters.length(); i++) {
+            requesters[i] = routeRequesters.at(i);
+            vaults[i] = vaultRoutes[routeRequesters.at(i)];
+        }
+    }
+
     function updateOrderSigner(address orderSigner_) external onlyOwner {
         address oldOrderSigner = orderSigner;
         require(orderSigner_ != address(0), "orderSigner is zero address");
@@ -210,6 +248,7 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
         hedgeOrder_.requester = hedgeOrder.requester;
         hedgeOrder_.receiver = hedgeOrder.receiver;
         hedgeOrder_.token = hedgeOrder.token;
+        hedgeOrder_.vault = hedgeOrder.vault;
         orderHashs.add(orderHash);
     }
 
@@ -227,6 +266,8 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
             token = IERC20(address(assetToken));
         } else {
             token = IERC20(hedgeOrder.token);
+            require(hedgeOrder.vault != address(0), "vault is zero address");
+            require(getVaultRoute(hedgeOrder.requester) == hedgeOrder.vault, "vault not match");
         }
         setHedgeOrder(orderHash, hedgeOrder);
         orderStatus[orderHash] = HedgeOrderStatus.PENDING;
@@ -285,8 +326,8 @@ contract USSI is Initializable, OwnableUpgradeable, AccessControlUpgradeable, ER
             }
             issuer.burnFor(hedgeOrder.assetID, hedgeOrder.inAmount);
         } else {
-            require(vault != address(0), "vault is zero address");
-            IERC20(hedgeOrder.token).safeTransfer(vault, hedgeOrder.inAmount);
+            require(hedgeOrder.vault != address(0), "vault is zero address");
+            IERC20(hedgeOrder.token).safeTransfer(hedgeOrder.vault, hedgeOrder.inAmount);
         }
         emit ConfirmMint(orderHash);
     }

--- a/test/Staking.t.sol
+++ b/test/Staking.t.sol
@@ -223,7 +223,8 @@ contract StakingTest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: hedger,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         vm.startPrank(hedger);
         vm.expectRevert();
@@ -258,7 +259,8 @@ contract StakingTest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: hedger,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         orderHash = keccak256(abi.encode(redeemOrder));
         (v, r, s) = vm.sign(orderSignerPk, orderHash);
@@ -293,7 +295,8 @@ contract StakingTest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: hedger,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         vm.startPrank(owner);
         uSSI.grantRole(uSSI.PARTICIPANT_ROLE(), hedger);
@@ -326,7 +329,8 @@ contract StakingTest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: hedger,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         orderHash = keccak256(abi.encode(redeemOrder));
         (v, r, s) = vm.sign(orderSignerPk, orderHash);

--- a/test/Ussi.t.sol
+++ b/test/Ussi.t.sol
@@ -179,7 +179,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         // Sign the order
@@ -215,7 +216,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: hedger,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(orderSignerPk, orderHash);
@@ -250,7 +252,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -293,7 +296,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -334,7 +338,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         // Sign the order
@@ -373,7 +378,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: hedger,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -417,7 +423,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -443,6 +450,7 @@ contract USSITest is Test {
         assertEq(ussi.balanceOf(address(hedger)), 0);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_CancelRedeem() public {
         // Mint USSI tokens first
         deal(address(ussi), hedger, USSI_AMOUNT);
@@ -459,7 +467,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -505,7 +514,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -584,7 +594,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -636,7 +647,8 @@ contract USSITest is Test {
                 deadline: block.timestamp + 600,
                 requester: hedger,
                 receiver: receiver,
-                token: address(0)
+                token: address(0),
+                vault: address(0)
             });
 
             bytes32 orderHash_mint = keccak256(abi.encode(mintOrder));
@@ -676,7 +688,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(validMintOrder));
@@ -708,7 +721,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         wrongAssetOrder.assetID = 999;
         orderHash = keccak256(abi.encode(wrongAssetOrder));
@@ -730,7 +744,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         expiredOrder.deadline = block.timestamp - 1;
         orderHash = keccak256(abi.encode(expiredOrder));
@@ -802,7 +817,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -833,7 +849,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
         wrongRedeemTokenOrder.redeemToken = address(WETH);
         orderHash = keccak256(abi.encode(wrongRedeemTokenOrder));
@@ -856,7 +873,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -908,7 +926,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -957,7 +976,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -998,7 +1018,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 redeemOrderHash = keccak256(abi.encode(redeemOrder));
@@ -1031,7 +1052,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -1072,7 +1094,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 mintOrderHash = keccak256(abi.encode(mintOrder));
@@ -1109,7 +1132,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -1143,7 +1167,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 redeemOrderHash = keccak256(abi.encode(redeemOrder));
@@ -1159,6 +1184,7 @@ contract USSITest is Test {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_CancelRedeem_Revert() public {
         // Create a redeem order
         deal(address(ussi), hedger, USSI_AMOUNT);
@@ -1173,7 +1199,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 orderHash = keccak256(abi.encode(redeemOrder));
@@ -1207,7 +1234,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: address(0)
+            token: address(0),
+            vault: address(0)
         });
 
         bytes32 mintOrderHash = keccak256(abi.encode(mintOrder));
@@ -1331,6 +1359,7 @@ contract USSITest is Test {
         // Add a supported token
         address newToken = address(new MockToken("Test Token", "TEST", 18));
         ussi.addSupportToken(newToken);
+        ussi.updateVault(vm.addr(0x123));
         vm.stopPrank();
 
         // Mint tokens to hedger
@@ -1348,7 +1377,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: newToken
+            token: newToken,
+            vault: ussi.vault()
         });
 
         // Sign the order
@@ -1376,6 +1406,7 @@ contract USSITest is Test {
         // Add a supported token
         address newToken = address(new MockToken("Test Token", "TEST", 18));
         ussi.addSupportToken(newToken);
+        ussi.updateVault(vm.addr(0x123));
         vm.stopPrank();
 
         // Mint tokens to hedger
@@ -1393,7 +1424,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: newToken
+            token: newToken,
+            vault: ussi.vault()
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -1428,6 +1460,7 @@ contract USSITest is Test {
         // Add a supported token
         address newToken = address(new MockToken("Test Token", "TEST", 18));
         ussi.addSupportToken(newToken);
+        ussi.updateVault(vm.addr(0x123));
         vm.stopPrank();
 
         // Mint tokens to hedger
@@ -1445,7 +1478,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: newToken
+            token: newToken,
+            vault: ussi.vault()
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -1475,9 +1509,8 @@ contract USSITest is Test {
         // Add a supported token
         address newToken = address(new MockToken("Test Token", "TEST", 18));
         ussi.addSupportToken(newToken);
-        
-        // Set up vault address
-        address newVault = address(0x123);
+        ussi.updateVault(vm.addr(0x123));
+        ussi.addVaultRoute(hedger, vm.addr(0x999));
         vm.stopPrank();
 
         // Mint tokens to hedger
@@ -1495,7 +1528,8 @@ contract USSITest is Test {
             deadline: block.timestamp + 600,
             requester: hedger,
             receiver: receiver,
-            token: newToken
+            token: newToken,
+            vault: ussi.getVaultRoute(hedger)
         });
 
         bytes32 orderHash = keccak256(abi.encode(mintOrder));
@@ -1507,14 +1541,8 @@ contract USSITest is Test {
         ussi.applyMint(mintOrder, orderSign);
         vm.stopPrank();
 
-        // Test confirming with zero vault address
-        vm.startPrank(owner);
-        vm.expectRevert("vault is zero address");
-        ussi.confirmMint(orderHash);
-        
-        // Set vault back to valid address
-        ussi.updateVault(newVault);
         // Confirm minting
+        vm.startPrank(owner);
         ussi.confirmMint(orderHash);
         vm.stopPrank();
 
@@ -1523,9 +1551,70 @@ contract USSITest is Test {
 
         // Verify USSI tokens have been minted
         assertEq(ussi.balanceOf(hedger), USSI_AMOUNT);
-        
+
         // Verify tokens have been transferred to vault
-        assertEq(IERC20(newToken).balanceOf(newVault), MINT_AMOUNT);
+        assertEq(IERC20(newToken).balanceOf(vm.addr(0x999)), MINT_AMOUNT);
         assertEq(IERC20(newToken).balanceOf(address(ussi)), 0);
+    }
+
+    function test_addVaultRoute() public {
+        vm.startPrank(owner);
+        ussi.addVaultRoute(vm.addr(0x123), vm.addr(0x456));
+        vm.stopPrank();
+
+        // Verify the vault route has been added
+        assertEq(ussi.vaultRoutes(vm.addr(0x123)), vm.addr(0x456));
+    }
+
+    function test_addVaultRoute_Revert() public {
+        vm.startPrank(owner);
+        vm.expectRevert("vault is zero address");
+        ussi.addVaultRoute(vm.addr(0x123), address(0));
+        vm.stopPrank();
+    }
+
+    function test_addVaultRoute_Revert_AlreadyExists() public {
+        vm.startPrank(owner);
+        ussi.addVaultRoute(vm.addr(0x123), vm.addr(0x456));
+        vm.expectRevert("vault route not change");
+        ussi.addVaultRoute(vm.addr(0x123), vm.addr(0x456));
+        vm.stopPrank();
+    }
+
+    function test_removeVaultRoute() public {
+        vm.startPrank(owner);
+        ussi.addVaultRoute(vm.addr(0x123), vm.addr(0x456));
+        ussi.removeVaultRoute(vm.addr(0x123));
+        vm.stopPrank();
+
+        // Verify the vault route has been removed
+        assertEq(ussi.vaultRoutes(vm.addr(0x123)), address(0));
+    }
+
+    function test_removeVaultRoute_Revert() public {
+        vm.startPrank(owner);
+        vm.expectRevert("vault route not exists");
+        ussi.removeVaultRoute(vm.addr(0x123));
+        vm.stopPrank();
+    }
+
+    function test_getVaultRoutes() public {
+        vm.startPrank(owner);
+        ussi.addVaultRoute(vm.addr(0x123), vm.addr(0x456));
+        vm.stopPrank();
+        (address[] memory requesters, address[] memory vaults) = ussi.getVaultRoutes();
+        assertEq(requesters.length, 1);
+        assertEq(vaults.length, 1);
+        assertEq(requesters[0], vm.addr(0x123));
+        assertEq(vaults[0], vm.addr(0x456));
+    }
+
+    function test_getVaultRoute() public {
+        vm.startPrank(owner);
+        ussi.updateVault(vm.addr(0x456));
+        ussi.addVaultRoute(vm.addr(0x123), vm.addr(0x789));
+        vm.stopPrank();
+        assertEq(ussi.getVaultRoute(vm.addr(0x123)), vm.addr(0x789));
+        assertEq(ussi.getVaultRoute(vm.addr(0x999)), vm.addr(0x456));
     }
 }

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -29,6 +29,7 @@ contract UtilsTest is Test {
         assertEq(result, expected);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     // Test error cases for the stringToAddress function
     function test_StringToAddress_InvalidLength() public {
         // Test too short
@@ -40,12 +41,14 @@ contract UtilsTest is Test {
         Utils.stringToAddress("0x1234567890123456789012345678901234567890123");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_StringToAddress_InvalidPrefix() public {
         // Test prefix is not 0x
         vm.expectRevert("Invalid address prefix");
         Utils.stringToAddress("1x1234567890123456789012345678901234567890");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexCharToByte_InvalidChar() public {
         // Test invalid hex character
         vm.expectRevert("Invalid hex character");
@@ -163,6 +166,7 @@ contract UtilsTest is Test {
         assertEq(result[0].amount, 200);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     // Test error cases for the subTokenset function
     function test_SubTokenset_InsufficientAmount() public {
         // Create a Token array for testing
@@ -190,6 +194,7 @@ contract UtilsTest is Test {
         Utils.subTokenset(a, b);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_SubTokenset_NotContains() public {
         // Create a Token array for testing
         Token[] memory a = new Token[](1);
@@ -499,6 +504,7 @@ contract UtilsTest is Test {
         assertTrue(Utils.hasDuplicates(b));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     // Test the validateTokenset function
     function test_ValidateTokenset() public {
         // Create a valid Token array


### PR DESCRIPTION
## Description
This PR adds vault routing functionality to the USSI contract, allowing different requesters to have their own vault addresses while maintaining a default vault fallback.

### Key Changes
1. Added vault routing system:
   - New `vaultRoutes` mapping to store requester-specific vault addresses
   - New `routeRequesters` set to track requesters with custom vaults
   - Added `vault` field to `HedgeOrder` struct
   - New functions: `getVaultRoute`, `addVaultRoute`, `removeVaultRoute`, `getVaultRoutes`

2. Updated mint/redeem logic:
   - Modified to use requester-specific vaults when available
   - Added validation for vault addresses
   - Updated token transfer logic to use the correct vault

3. Added comprehensive test coverage:
   - New test cases for vault routing functionality
   - Updated existing tests to support vault routing
   - Added forge configuration for internal revert tests

4. Other changes:
   - Added `via_ir = true` to foundry.toml for better gas optimization
   - Removed unused console import
   - Added forge configuration comments for internal revert tests

### Testing
All tests have been updated and pass, including:
- Vault routing functionality tests
- Mint/redeem operation tests with custom vaults
- Error case handling tests

### Security Considerations
- Only owner can add/remove vault routes
- Zero address checks for vault addresses
- Validation of vault addresses during mint/redeem operations